### PR TITLE
Reduced amount of default logging

### DIFF
--- a/Projects/SSEKit/SSEKit/SSEManager.swift
+++ b/Projects/SSEKit/SSEKit/SSEManager.swift
@@ -61,7 +61,7 @@ open class SSEManager : NSObject, URLSessionDelegate  {
     
 	public override init() {
 		SSEManager.instanceCount = SSEManager.instanceCount + 1
-		NSLog("SSEManager init - instances \(SSEManager.instanceCount)")
+//		NSLog("SSEManager init - instances \(SSEManager.instanceCount)")
 	}
 	
 	@available(*, deprecated, message: "EventSourceConfiguration to be removed")
@@ -74,7 +74,7 @@ open class SSEManager : NSObject, URLSessionDelegate  {
 	
 	deinit {
 		SSEManager.instanceCount = SSEManager.instanceCount - 1
-		NSLog("SSEManager dealloc - deinit \(SSEManager.instanceCount)")
+//		NSLog("SSEManager dealloc - deinit \(SSEManager.instanceCount)")
 	}
 	
 	/// connect to the given SSE endpoint
@@ -288,7 +288,7 @@ extension SSEManager: URLSessionDataDelegate {
 		
 			if self.connectionState == .connecting {
 				
-				NSLog("\(response)")
+//				NSLog("\(response)")
 				switch response.statusCode {
 					
 				case 200...299:


### PR DESCRIPTION

While trying to debug something using the iOS simulator I found the default level of logging has crept up a lot recently. I have done the following:
1. Reduced the default level of logging for modules that have log level control
2. Deleted log statements that have no context or are obviously left over from debug sessions in the distant past
3. Commented out debug that looks like it has a purpose but has little contextual info in the log. If you revisit this module and want to re-enable it do so in a conditional manner so a given module can have it's debug enabled/disabled
4. Added some context to debug messages that are flagging errors but had little contextual info in the log message